### PR TITLE
Allow JFIF images

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const SHARP = require("sharp");
 const S3 = new AWS.S3();
 
 const { BUCKET, BUCKET_URL, SCALED_FOLDER } = process.env;
-const ALLOWED_EXTENSIONS = ["jpeg", "png", "webp", "gif", "svg"];
+const ALLOWED_EXTENSIONS = ["jpeg", "png", "webp", "gif", "svg", "jfif"];
 
 module.exports.handler = async function handler(event, context, callback) {
   try {
@@ -45,7 +45,7 @@ module.exports.handler = async function handler(event, context, callback) {
         : await SHARP(object.Body)
             .withMetadata()
             .resize(options)
-            .toFormat(outputFormat, { progressive: true })
+            .toFormat(toSharpOutputFormat(outputFormat), { progressive: true })
             .toBuffer();
 
     /**
@@ -141,4 +141,14 @@ function pathToParams(path) {
   const [originalFilename, outputFormat, originalExtension] =
     parseFilename(filename);
   return [size, originalFilename, outputFormat, originalExtension];
+}
+
+/**
+ * Correct certain output formats to something that Sharp understands.
+ * Note that we never change the output format in the extension of
+ * the output file, since that would defeat the purpose of
+ * redirecting the user back to the scaled URL.
+ */
+function toSharpOutputFormat(format) {
+  return format === "jfif" ? "jpg" : format;
 }


### PR DESCRIPTION
> A .JFIF file is a JPEG File Interchange Format file. The JFIF file format is the successor of the JIF file format. Both are variations of JPEG image files that were invented in 1992. The JIF file format had some shortcomings that made it difficult to make encoders and decoders compatible, and the JFIF format tried to improve this. JFIF has later been superseded by the newer Exif format.
> 
> So, in short, JFIF files are actually JPEG image files using a slightly different file format, which is now obsolete.

--- 

Process these as if they are JPEG.  
Over at Heembouw, we encountered a JFIF file in the wild.

Note: yes, this really needs an extensive snapshot test suite, to account for cases like this. It's on the list. 😓 