### PR TITLE
Cloudfront origin group support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,33 +8,35 @@ on:
 jobs:
   eslint:
     name: Eslint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
+          cache: "yarn"
       - run: yarn install
       - run: npx eslint .
 
   prettier:
     name: Prettier
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
+          cache: "yarn "
       - run: yarn install
       - run: npx prettier --check .
 
   tests:
     name: Run unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
           cache: "yarn"
@@ -43,7 +45,7 @@ jobs:
 
   notification:
     name: Slack notification
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: ${{ always() && github.actor != 'dependabot[bot]' }}
     needs: [eslint, prettier, tests]
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Use the URL you got from Serverless' output to configure a redirect rule:
       "HostName": "0123456789.execute-api.eu-central-1.amazonaws.com",
       "HttpRedirectCode": "307",
       "Protocol": "https",
-      "ReplaceKeyPrefixWith": "default/resize?key="
+      "ReplaceKeyPrefixWith": "default/resize?key=scaled"
     }
   }
 ]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ npx serverless deploy --stage staging|production
 
 Note the URL in Serverless' terminal output.
 
+The function can work with a Website Configuration Redirection Rule or as a CloudFront Origin. It's not necessary to configure both.
+
 ### Use the microservice as a redirect rule in the bucket
 
 In your AWS console, go to your bucket, edit its properties.

--- a/README.md
+++ b/README.md
@@ -139,14 +139,34 @@ Note some things:
 
 - The value for `HostName` is the hostname you got from Serverless.
 - The value for `Condition.KeyPrefixEquals` is whatever you've configured as `SCALED_FOLDER` in the environment variables.
-- The value for `HttpErrorCodeReturnedEquals` might be `403` or `404` based on your bucket and CloudFront settings.
+- The value for `HttpErrorCodeReturnedEquals` might be `403` or `404` based on your bucket. 403 when the objects in the bucket aren't public, 404 when they are.
 
 #### Let's see if it works!
 
 Upload an image to your bucket (make sure it's publicly readable), for example `foobar.jpg`.
 
-Now access this URL and see if it's worked: `https://<BUCKET_URL>/scaled/500x500/foobar.jpg.webp`.  
+Now access this URL and see if it's working: `https://<BUCKET_URL>/scaled/500x500/foobar.jpg.webp`.  
 If not, the first step in debugging is to go to the Lambda function in the AWS Console and check the CloudWatch logs.
+
+Good luck!
+
+### Use a CloudFront failover origin group
+
+In your AWS console, go to your CloudFront distribution. Under <strong>Origins</strong> to can add a second origin, beside your S3 bucket.
+
+Add an origin with the name "ImageScaler" and "Origin domain" (`0123456789.execute-api.eu-central-1.amazonaws.com`) should be the host of the API Gateway URL. Add the path of that url to "Origin path" (`default/resize?key=`).
+
+Create an Origin group with the S3Origin as a primary. The ImageScaler orign as secondary. Name it "Image scaler fallback" and 403 as criteria.
+
+The last step is changing the "Origin and origin group" property of the behavior. Go to Behaviors and edit the default behavior. Choose the created Origin group.
+
+Save and wait for AWS to deploy the changes.
+
+#### Let's see if it works!
+
+Upload an image to your bucket, for example, `foobar.jpg`.
+
+Now access this URL and see if it's working: `https://<CLOUDFRONT_DISTRIBUTION>/scaled/500x500/foobar.jpg.webp`. If not, the first step in debugging is to go to the Lambda function in the AWS Console and check the CloudWatch logs.
 
 Good luck!
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const deflateImage = require("./util/deflate-image.js");
 
 const S3 = new AWS.S3();
 
-const { BUCKET, BUCKET_URL, IMAGE_ACL } = process.env;
+const { BUCKET, IMAGE_ACL } = process.env;
 const ALLOWED_EXTENSIONS = ["jpeg", "jpg", "png", "webp", "gif", "svg", "jfif"];
 
 module.exports.handler = async function handler(event, context, callback) {

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,10 +18,9 @@ provider:
   lambdaHashingVersion: 20201221
   apiGateway:
     binaryMediaTypes:
-      - '*/*'
+      - "*/*"
   environment:
     BUCKET: ${env:BUCKET}
-    BUCKET_URL: ${env:BUCKET_URL}
     IMAGE_ACL: ${env:IMAGE_ACL,""}
 
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,7 @@
 service: ${env:SERVICE_NAME,"imageScaler"}
 
 useDotenv: true
+variablesResolutionMode: 20210219
 configValidationMode: error
 
 provider:
@@ -14,10 +15,13 @@ provider:
   runtime: nodejs16.x
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}
+  lambdaHashingVersion: 20201221
+  apiGateway:
+    binaryMediaTypes:
+      - '*/*'
   environment:
     BUCKET: ${env:BUCKET}
     BUCKET_URL: ${env:BUCKET_URL}
-    SCALED_FOLDER: ${env:SCALED_FOLDER}
     IMAGE_ACL: ${env:IMAGE_ACL,""}
 
 functions:

--- a/test/pathToParams.test.js
+++ b/test/pathToParams.test.js
@@ -3,7 +3,7 @@ const pathToParams = require("../util/pathToParams.js");
 describe("pathToParams", () => {
   describe("Given a URL with unsupported extension", () => {
     it("Will throw an error", () => {
-      const input = "500x320/foo.jpg";
+      const input = "scaled/500x320/foo.jpg";
       expect(() => pathToParams(input, ["png"])).toThrow(
         "Unable to produce output jpg."
       );
@@ -12,7 +12,7 @@ describe("pathToParams", () => {
 
   describe("Given a URL with both dimensions and no output-format", () => {
     it("Will extract dimensions and use the original extension as outputFormat", () => {
-      const input = "500x320/foo.jpg";
+      const input = "scaled/500x320/foo.jpg";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg"]
@@ -25,7 +25,7 @@ describe("pathToParams", () => {
   });
   describe("Given a URL with just a width", () => {
     it("Will still extract the dimensions", () => {
-      const input = "/500x/foo.jpg";
+      const input = "/scaled/500x/foo.jpg";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg"]
@@ -38,7 +38,7 @@ describe("pathToParams", () => {
   });
   describe("Given a URL with just a height", () => {
     it("Will still extract the dimensions", () => {
-      const input = "/x500/foo.jpg";
+      const input = "/scaled/x500/foo.jpg";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg"]
@@ -51,7 +51,7 @@ describe("pathToParams", () => {
   });
   describe("Given a URL with a longer directory path", () => {
     it("Will extract the correct path", () => {
-      const input = "/500x500/my/deeper/folder/foo.jpg";
+      const input = "/scaled/500x500/my/deeper/folder/foo.jpg";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg"]
@@ -64,7 +64,7 @@ describe("pathToParams", () => {
   });
   describe("Given a file with a double extension", () => {
     it("Will treat the first extension as part of the original filename, and the last part as the outputFormat", () => {
-      const input = "/300x120/foo.jpg.png";
+      const input = "/scaled/300x120/foo.jpg.png";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg", "png"]
@@ -75,7 +75,7 @@ describe("pathToParams", () => {
       expect(originalExtension).toBe("jpg");
     });
     it("Will only look at double extensions if they're both in the allowed list.", () => {
-      const input = "/300x120/foo.zip.jpg";
+      const input = "/scaled/300x120/foo.zip.jpg";
       const [size, path, outputFormat, originalExtension] = pathToParams(
         input,
         ["jpg"]

--- a/util/pathToParams.js
+++ b/util/pathToParams.js
@@ -1,7 +1,7 @@
 function pathToParams(path, allowedExtensions) {
   // Allow for subfolders, by using a spread operator.
   const cleanPath = path.startsWith("/") ? path.substring(1) : path;
-  const [size, ...filenameParts] = cleanPath.split("/");
+  const [, size, ...filenameParts] = cleanPath.split("/");
   const filename = filenameParts.join("/");
   const [originalFilename, outputFormat, originalExtension] = parseFilename(
     filename,


### PR DESCRIPTION
Ik heb de image scaler met CloudFront aan de praat. Ammodo draait op deze branch. ~Er zitten wel haken en ogen aan die volgende week in onze meeting hierover moeten behandelen~

- ~Key parameter wordt niet aangepast, dus "/scaled" wordt niet vervangen door "default/resize?key=" maar toegevoegd.~
- ~Breaking changes zijn niet mogelijk, want alle installatie gebruiken de default branch~
- ~Output van de functie is nu een redirect, dus dat wordt gecached door CF. Maar ik denk dat we ook de data kunnen terugsturen.~

====

- BREAKING CHANGE Website redirects moeten `default/resize?key=scaled` worden.
- CHANGE We hebben de output veranderd van een redirect naar de daadwerkelijke afbeelding. Dat werkt zowel met CloudFront als website redirects.
- CHANGE De env vars `BUCKET_URL` en `SCALED_URL` zijn komen te vervallen.

Ik heb de branch `v1.0` gemaakt en de tag `v1.0.0`. Daarmee kunnen we bestaande versie pinnen. Op `main` kunnen we dan verder ontwikkelen, maar nog wel eventuele change in de `v1.0` branch doorvoeren.