### PR TITLE
Use arm64 architecture instead of x86_64

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
     Project: ${env:PROJECT_NAME,env:SERVICE_NAME}
   iam:
     role: ${env:SERVERLESS_ROLE}
+  architecture: arm64
   runtime: nodejs16.x
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,8 +15,6 @@ provider:
     Project: ${env:PROJECT_NAME,env:SERVICE_NAME}
   iam:
     role: ${env:SERVERLESS_ROLE}
-  architecture: arm64
-  runtime: nodejs16.x
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}
   lambdaHashingVersion: 20201221
@@ -31,6 +29,9 @@ functions:
   main:
     handler: index.handler
     description: "Scale images at runtime."
+    architecture: ${env:ARCHITECTURE,"x86_64"}
+    memorySize: ${env:MEMORY_SIZE,1024}
+    runtime: nodejs16.x
     events:
       - http:
           path: resize


### PR DESCRIPTION
Snelle test gedaan met arm64 support. Het werkt nog niet, omdat de image scaler een aantal binaries moeten compilen. Dat doen we in de workflows en die draaien ubuntu op x86_64, niet op arm64. Het kan ongetwijfeld, maar dat moet verder onderzocht worden. Github heeft zo snel ik kan zien geen runner die op arm64 draait.