### PR TITLE
Several improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,4 @@ BUCKET=
 
 # Deployment options:
 DEPLOYMENT_BUCKET=
-AWS_REGION=eu-central-1
 SERVERLESS_ROLE=

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ cp .env.example .env
 
 The following environment variables are mandatory:
 
-- `AWS_REGION`: the region to deploy the Lambda function to. Required when deploying using Serverless.
 - `BUCKET`: the bucket in which your images are stored.
 - `DEPLOYMENT_BUCKET`: the bucket to hold your Serverless deploys. Required when deploying using Serverless.
 - `PROJECT_NAME` : Give AWS resources a Project tag with this value, defaults to `SERVICE_NAME`.
@@ -136,7 +135,7 @@ This allows the Lambda function to read and write from the bucket.
 Deploy using the Serverless framework:
 
 ```sh
-npx serverless deploy --stage staging|production
+npx serverless deploy --stage staging|production --region eu-central-1
 ```
 
 Note the URL in Serverless' terminal output.

--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ The role must have the following policy attached:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": ["s3:ListBucket"],
+      "Action": "s3:ListBucket",
       "Resource": "<YOUR-BUCKET-NAME-HERE>"
     },
     {
       "Effect": "Allow",
-      "Action": "s3:*",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:PutObjectAcl"],
       "Resource": "<YOUR-BUCKET-NAME-HERE>/*"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "homepage": "https://github.com/grrr-amsterdam/s3-image-scaler#readme",
   "dependencies": {
-    "aws-sdk": "^2.768.0",
     "express": "^4.18.2",
     "sharp": "^0.30.1"
   },
   "devDependencies": {
+    "aws-sdk": "^2.1359.0",
     "eslint": "^8.8.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,3 +40,8 @@ resources:
     MainLogGroup:
       Properties:
         RetentionInDays: "14"
+        Tags:
+          - Key: "ManagedBy"
+            Value: "Serverless"
+          - Key: "Project"
+            Value: ${env:PROJECT_NAME,env:SERVICE_NAME}

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ configValidationMode: error
 provider:
   name: aws
   # The AWS region in which to deploy (us-east-1 is the default)
-  region: ${env:AWS_REGION}
+  region: ${env:AWS_REGION,opt:region}
   # The stage of the application, e.g. dev, production, staging…
   stage: ${opt:stage,"development"}
   tags:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,20 +1056,21 @@ aws-sdk@^2.1174.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
-aws-sdk@^2.768.0:
-  version "2.987.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.987.0.tgz#a6e952ae3d3adf352516402d88397fbe2b9e3480"
-  integrity sha512-XgMrHWHE3aKg11D4QSlpyLvsGw6mHHiUQuowbswd11k89Q6wEfA+jMbYMC7/jsx3LrH9EKti70qhfZyw/wQIfg==
+aws-sdk@^2.1359.0:
+  version "2.1359.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1359.0.tgz#2cde4dce72a6681a9ac5b3c751545e13e5fec850"
+  integrity sha512-uGNIU4czx8P0YITV8uhuLFhmyYvLWsFYINlHJX77/fea4VuTwcCGktYy2OEnrErp3FK9NHQvwXBxZCbY0lcxBg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
     ieee754 "1.1.13"
-    jmespath "0.15.0"
+    jmespath "0.16.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.5.0"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -3709,11 +3710,6 @@ jest@^27.5.1:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==
-
 jmespath@0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
@@ -5743,11 +5739,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
 uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
@@ -5959,6 +5950,19 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml2js@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
- Replace `AWS_REGION` with `--region` flag. That's how [the Serverless docs](https://www.serverless.com/framework/docs/providers/aws/guide/variables#referencing-aws-specific-variables) say it works.
- Add tags to the CloudWatch log group to make it consistent with the Lambda function.
- Reduce function size by 10MB by making `aws-sdk` a dev dependency. The Lambda runtime already contains the package. By making it a dev dependency, autocompletion keeps working. But won't end up in the function.
- Improve documentation.