### PR TITLE
Disable Lambda versions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
   iam:
     role: ${env:SERVERLESS_ROLE}
   runtime: nodejs16.x
+  versionFunctions: false
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}
   environment:

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ provider:
     BUCKET_URL: ${env:BUCKET_URL}
     SCALED_FOLDER: ${env:SCALED_FOLDER}
     IMAGE_ACL: ${env:IMAGE_ACL,""}
-    IMAGE_QUALITY: ${env:IMAGE_QUALITY}
+    IMAGE_QUALITY: ${env:IMAGE_QUALITY,80}
 
 functions:
   main:


### PR DESCRIPTION
Previously deploys functions won't be removed by Serverless or AWS. It just piles up. For Lambda@Edge it's necessary, but the image scaler always uses the latest deployed version.

When you don't want to disable versions use your own copy of serverless.example.yml.