### PR TITLE
Upgrade node runtime to version 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "yarn"
       - run: yarn install
       - run: npx eslint .
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "yarn"
       - run: yarn install
       - run: npx prettier --check .
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "yarn"
       - run: yarn install
       - run: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upgrade to V5
+
+Breaking: the node runtime has been updated to version 24.
+Update `runtime` in your copy of `serverless.example.yml` to `nodejs24.x` and ensure your deploy workflows use the correct node version.
+
 # Upgrade to V4.3.0
 
 The node runtime has been updated to version 22.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# s3-image-scaler — Claude Code instructies
+
+Dit bestand geldt voor iedereen die Claude Code in deze repo gebruikt. Lees het van begin tot eind voordat je begint.
+
+## Project-context
+
+Open-source microservice (MIT, GRRR/grrr-amsterdam) die S3-afbeeldingen on the fly schaalt en converteert. De service draait als 404-handler voor een S3-bucket: bij een miss op een pad als `/scaled/width:500_height:500/foo.jpg` genereert de Lambda de variant en schrijft die terug naar de bucket, zodat vervolgrequests de statische file raken.
+
+- Node.js 24 op AWS Lambda, gedeployd met Serverless (`osls`), package manager is yarn.
+- Plain JavaScript (CommonJS), geen TypeScript.
+- Beeldbewerking via Sharp. Let op: de Sharp-binaries in `node_modules` zijn gebouwd voor Linux x64 (het Lambda-platform) en werken dus niet lokaal op macOS. Herinstalleren gaat met `npm_config_platform=linux npm_config_arch=x64 yarn add sharp`.
+- Kernlogica staat in `util/` (pure functies per bestand), de Lambda-handler in `index.js`, een lokale dev-server in `server/` en een CLI-resizer in `cli/`.
+- Branch-per-major-versie: `v1.0`, `v2.x`, `v3.x`, `v4.x`, … Nieuwe features gaan naar de nieuwste versie-branch, bugfixes naar de oudste branch waarin de bug zit. Deploys worden gepind op een git-tag; wijzigingen komen in `CHANGELOG.md`.
+- Wijzig je iets aan de conversieregels, voeg dan altijd een unit test toe die het bedoelde gedrag vastlegt.
+
+## Tooling en commando's
+
+- Tests: `yarn test` (Jest). ⚠️ De fixture-vergelijkende tests slagen alleen op macOS — Sharp-output op Linux wijkt licht af.
+- Lint: `npx eslint .`
+- Format: `npx prettier --write <files>`
+- Dev-server: `yarn serve` (lokale image-server op http://localhost:8888, werkt offline zonder AWS)
+- CLI-resize: `node cli/resize-image.js <bron> <opties> <doel>`
+- Deploy: `npx serverless deploy --stage=staging|production --region eu-central-1`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Microservice for scaling S3-stored images on the fly.",
   "main": "index.js",
   "engines": {
-    "node": "22"
+    "node": "24"
   },
   "scripts": {
     "serve": "node server/index.js",

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -29,7 +29,7 @@ provider:
               - - "arn:aws:s3:::"
                 - ${param:bucket}
                 - "/*"
-  runtime: nodejs22.x
+  runtime: nodejs24.x
   versionFunctions: false
   deploymentBucket:
     name: serverless.deployments.grrr

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ provider:
     Project: ${env:PROJECT_NAME,env:SERVICE_NAME}
   iam:
     role: ${env:SERVERLESS_ROLE}
-  runtime: nodejs22.x
+  runtime: nodejs24.x
   versionFunctions: false
   deploymentBucket:
     name: ${env:DEPLOYMENT_BUCKET}

--- a/specs/2026-08-15-node-24-compatibiliteit.md
+++ b/specs/2026-08-15-node-24-compatibiliteit.md
@@ -1,0 +1,29 @@
+# Node 24-compatibiliteit
+
+`2026-08-15` · Ramiro Hammen · TODO: ticket/PR-link
+
+## Waarom
+
+AWS faseert de huidige Lambda-runtime uit; blijven we op `nodejs22.x`, dan kunnen we op termijn niet meer deployen of de functie updaten. De service moet daarom over op de `nodejs24.x`-runtime, en lokaal ontwikkelen, CI en deploy moeten op Node 24 blijven werken.
+
+## Scope
+
+- **Wel:** alle Node-versie-pins bijwerken naar 24 (`package.json` engines, `serverless.yml`, `serverless.example.yml`, CI-workflows).
+- **Niet:** Sharp bumpen — 0.33.5 draait op Node 24 (prebuilt Node-API-binaries, engines staan ≥21 toe); een bump naar 0.34/0.35 verandert de beelduitvoer en vergt fixture-regeneratie, dat is een losse wijziging.
+- **Niet:** functionele wijzigingen aan de scaler (conversieregels, API, paden), refactors of nieuwe features.
+
+## Acceptatiecriteria
+
+1. `package.json` `engines.node` staat op `24`.
+2. `serverless.yml` en `serverless.example.yml` gebruiken `runtime: nodejs24.x` en `npx serverless print` valideert zonder fouten (`configValidationMode: error`).
+3. Alle CI-workflows draaien op `node-version: "24.x"` en zijn groen.
+4. `yarn test` slaagt lokaal op Node 24 (op macOS, conform de bestaande platform-beperking van de fixtures).
+5. Een staging-deploy op de `nodejs24.x`-runtime slaagt, en een testafbeelding wordt via `/scaled/width:500_height:500/...` correct geschaald en teruggeschreven naar de bucket.
+6. De wijziging landt op een nieuwe `v5.x`-branch en `CHANGELOG.md` vermeldt v5.0 met de runtime-wijziging als breaking change.
+
+## Uitgezocht
+
+- Versionering volgt semver: dit is een breaking change (`serverless.example.yml` wijzigt en de engines-pin laat Node 22 vallen), dus een nieuwe major → `v5.x`-branch.
+
+- `osls` 3.61.1 (de huidige versie) accepteert `runtime: nodejs24.x` al — geen tooling-bump nodig.
+- Sharp 0.33.5 draait ongewijzigd op Node 24: de engines-range (`>=21.0.0`) dekt Node 24 en de prebuilt binaries zijn Node-API-gebaseerd (ABI-stabiel). Fixtures blijven dus geldig.


### PR DESCRIPTION
## Samenvatting

- Werkt de Lambda-runtime bij naar `nodejs24.x` in `serverless.yml` en `serverless.example.yml` (aanleiding: AWS faseert de oudere runtime uit).
- Zet `engines.node` op `24` en de CI-workflows op `node-version: "24.x"`.
- Voegt een V5-entry toe aan `CHANGELOG.md`; de runtime-bump is een breaking change omdat consumers hun kopie van `serverless.example.yml` moeten aanpassen.
- Bevat de spec (`specs/2026-08-15-node-24-compatibiliteit.md`) met context en acceptatiecriteria.
- Voegt `CLAUDE.md` toe aan de v5.x-lijn (overgenomen uit #41, met de Node-versie bijgewerkt naar 24).

Geen dependency-bumps nodig: `osls` 3.61.1 accepteert `nodejs24.x` al en Sharp 0.33.5 draait ongewijzigd op Node 24 (Node-API-binaries), dus de test-fixtures blijven geldig.

## Test plan

- [x] `yarn test` slaagt lokaal op Node 24.18.0 / macOS (27 tests, 9 suites)
- [x] `npx serverless print` valideert de config met `runtime: nodejs24.x` (`configValidationMode: error`)
- [ ] CI groen op Node 24
- [ ] Staging-deploy op `nodejs24.x` en een testafbeelding via `/scaled/width:500_height:500/...` correct geschaald