### PR TITLE
Replace callback handler with async response

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ const S3 = new S3Client();
 const { BUCKET, IMAGE_ACL, IMAGE_QUALITY } = process.env;
 const quality = parseInt(IMAGE_QUALITY);
 
-module.exports.handler = async function handler(event, context, callback) {
+/**
+ * Note: this must be a callback-less async handler. AWS Lambda has removed
+ * support for callback-based handlers starting with the Node.js 24 runtime.
+ */
+module.exports.handler = async function handler(event) {
   try {
     const finalObjectKey = cleanupPath(event.queryStringParameters.key);
 
@@ -74,7 +78,7 @@ module.exports.handler = async function handler(event, context, callback) {
      * Redirect the user back to the originally requested path.
      * There should be a newly created image awaiting them.
      */
-    callback(null, {
+    return {
       statusCode: "200",
       headers: {
         "Content-Type": getImageMimetype(outputFormat),
@@ -82,13 +86,13 @@ module.exports.handler = async function handler(event, context, callback) {
       },
       isBase64Encoded: true,
       body: buffer.toString("base64"),
-    });
+    };
   } catch (err) {
     console.error(err);
-    callback(null, {
+    return {
       statusCode: "404",
       // TODO show generic error instead of real error.
       body: `An application error occurred: ${err.toString()}`, // "Object not found",
-    });
+    };
   }
 };


### PR DESCRIPTION
## Samenvatting

De eerste staging-deploy van v5 (bij WCE) faalde met een 502: de Lambda crasht bij init met `Runtime.CallbackHandlerDeprecated`. AWS heeft callback-based handlers verwijderd in de Node.js 24-runtime. De handler was al `async` maar riep nog `callback(null, response)` aan met een derde parameter — precies waarop de runtime weigert.

Deze fix laat de handler het response-object returnen en verwijdert de ongebruikte `context`/`callback`-parameters. Functioneel identiek gedrag (zelfde 200- en 404-responses).

## Test plan

- [x] `yarn test` groen (27 tests)
- [x] Smoke-test: handler heeft geen callback-parameter meer en returnt een response-object (404-pad lokaal doorlopen)
- [ ] Staging-redeploy bij WCE: scaled-URL levert weer een afbeelding